### PR TITLE
Use ordered_set for storing delayed messages

### DIFF
--- a/src/emqx_delayed_publish.erl
+++ b/src/emqx_delayed_publish.erl
@@ -103,7 +103,7 @@ store(DelayedMsg) ->
 
 init([]) ->
     ok = ekka_mnesia:create_table(?TAB, [
-                {type, set},
+                {type, ordered_set},
                 {disc_copies, [node()]},
                 {local_content, true},
                 {record_name, delayed_message},


### PR DESCRIPTION
Contrary to the description a `set` is currently used for storing the delayed messages. This results in messages being published in random order and with random delays. Instead, a `ordered_set` should be used to ensure correct behavior.

Fixes #15 